### PR TITLE
Include bundle type to modify specific bundle output in transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,14 @@ module.exports = function(eleventyConfig) {
 	eleventyConfig.addPlugin(bundlerPlugin, {
 		transforms: [
 			async function(content) {
-				// Same as Eleventy transforms, this.page is available here.
-				let result = await postcss([postcssNested]).process(content, { from: this.page.inputPath, to: null });
-				return result.css;
+				// this.type returns the bundle name.
+				if (this.type === 'css') {
+					// Same as Eleventy transforms, this.page is available here.
+					let result = await postcss([postcssNested]).process(content, { from: this.page.inputPath, to: null });
+					return result.css;
+				}
+
+				return content;
 			}
 		]
 	});

--- a/codeManager.js
+++ b/codeManager.js
@@ -79,12 +79,13 @@ class CodeManager {
 		}
 	}
 
-	async runTransforms(str, pageData) {
+	async runTransforms(str, pageData, buckets) {
 		for (let callback of this.transforms) {
 			str = await callback.call(
 				{
 					page: pageData,
-					type: this.name
+					type: this.name,
+					buckets: buckets
 				},
 				str
 			);

--- a/codeManager.js
+++ b/codeManager.js
@@ -83,7 +83,8 @@ class CodeManager {
 		for (let callback of this.transforms) {
 			str = await callback.call(
 				{
-					page: pageData
+					page: pageData,
+					type: this.name
 				},
 				str
 			);
@@ -125,7 +126,7 @@ class CodeManager {
 		let bundleContent = Array.from(set).join("\n");
 
 		// returns promise
-		return this.runTransforms(bundleContent, pageData);
+		return this.runTransforms(bundleContent, pageData, buckets);
 	}
 
 	async writeBundle(pageData, buckets, options = {}) {

--- a/test/stubs/use-transforms-on-type/eleventy.config.js
+++ b/test/stubs/use-transforms-on-type/eleventy.config.js
@@ -1,0 +1,19 @@
+const bundlePlugin = require("../../../");
+const postcss = require('postcss');
+const postcssNested = require('postcss-nested')
+
+module.exports = function(eleventyConfig) {
+	eleventyConfig.addPlugin(bundlePlugin, {
+		transforms: [async function(content) {
+			return new Promise(resolve => {
+				setTimeout(() => resolve(content), 50);
+			});
+		}, async function(content) {
+			if (this.type === "css") {
+				let result = await postcss([postcssNested]).process(content, { from: null, to: null })
+				return result.css;
+			}
+			return content;
+		}]
+	});
+};

--- a/test/stubs/use-transforms-on-type/index.liquid
+++ b/test/stubs/use-transforms-on-type/index.liquid
@@ -1,0 +1,9 @@
+<style>{% getBundle "css" %}</style>
+<script>{% getBundle "js" %}</script>
+
+{%- css %}* { color: blue; }{% endcss %}
+{%- css %}* { color: blue; }{% endcss %}
+{%- css %}* { color: red; }{% endcss %}
+{%- css %}#id { * { color: orange; } }{% endcss %}
+
+{%- js %}console.log("bundle me up"){% endjs %}

--- a/test/test.js
+++ b/test/test.js
@@ -262,6 +262,17 @@ test("Use Transforms", async t => {
 #id * { color: orange; }</style>`);
 });
 
+test("Use Transforms on specific bundle type", async t => {
+	let elev = new Eleventy("test/stubs/use-transforms-on-type/", undefined, {
+		configPath: "test/stubs/use-transforms-on-type/eleventy.config.js"
+	});
+	let results = await elev.toJSON();
+	t.deepEqual(normalize(results[0].content), `<style>* { color: blue; }
+* { color: red; }
+#id * { color: orange; }</style>
+<script>console.log("bundle me up")</script>`);
+});
+
 test("Output `defer` bucket multiple times (hoisting disabled)", async t => {
 	let elev = new Eleventy("test/stubs/output-same-bucket-multiple-times-nohoist/", undefined, {
 		configPath: "eleventy.bundle.js"


### PR DESCRIPTION
In the [Modify the bundle output](https://github.com/11ty/eleventy-plugin-bundle#modify-the-bundle-output) section of the README, it includes an example of how to integrate `postcss` in a transform function. Without a way of knowing the bundle type, this transform would cause the build to fail because it cannot process non-CSS code.

This PR will fix that issue by exposing the bundle name in a `type` variable available to the transform callbacks. This would allow for the `postcss` example to work like so:

```js
eleventyConfig.addPlugin(pluginBundle, {
    transforms: [
      async function (content) {
        if (this.type === "css") {
          let result = await postcss([postcssNested]).process(content, {
            from: this.page.inputPath,
            to: null,
          });
          return result.css;
        }

        return content;
      },
    ],
  });
```

I've included a test and also updated the README to reflect this change. Let me know if there's anything else I can provide!