### PR TITLE
Allow missing outputPath when running under Serverless

### DIFF
--- a/eleventy.shortcodes.js
+++ b/eleventy.shortcodes.js
@@ -61,7 +61,10 @@ module.exports = function(eleventyConfig, options = {}) {
 	});
 
 	eleventyConfig.addTransform("@11ty/eleventy-bundle", async function(content) {
-		if(typeof content !== "string") {
+		// `page.outputPath` is required to perform bundle transform, unless
+		// we're running in an Eleventy Serverless context.
+		let missingOutputPath = !this.page.outputPath && process.env.ELEVENTY_SERVERLESS !== "true";
+		if(missingOutputPath || typeof content !== "string") {
 			return content;
 		}
 

--- a/eleventy.shortcodes.js
+++ b/eleventy.shortcodes.js
@@ -61,7 +61,7 @@ module.exports = function(eleventyConfig, options = {}) {
 	});
 
 	eleventyConfig.addTransform("@11ty/eleventy-bundle", async function(content) {
-		if(!this.page.outputPath || typeof content !== "string") {
+		if(typeof content !== "string") {
 			return content;
 		}
 

--- a/test/stubs/serverless-stubs/functions/test1/eleventy-serverless-map.json
+++ b/test/stubs/serverless-stubs/functions/test1/eleventy-serverless-map.json
@@ -1,0 +1,3 @@
+{
+  "/": "./test/stubs/serverless-stubs/test1.liquid"
+}

--- a/test/stubs/serverless-stubs/functions/test1/eleventy.config.js
+++ b/test/stubs/serverless-stubs/functions/test1/eleventy.config.js
@@ -1,0 +1,5 @@
+const bundlePlugin = require("../../../../../");
+
+module.exports = function(eleventyConfig) {
+	eleventyConfig.addPlugin(bundlePlugin);
+};

--- a/test/stubs/serverless-stubs/test1.liquid
+++ b/test/stubs/serverless-stubs/test1.liquid
@@ -1,0 +1,6 @@
+---
+permalink:
+  test1: /
+---
+<style>{% getBundle "css" %}</style>
+{%- css %}* { color: blue; }{% endcss %}

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 const test = require("ava");
 const fs = require("fs");
 const Eleventy = require("@11ty/eleventy");
+const { EleventyServerless } = require("@11ty/eleventy");
 const { EleventyRenderPlugin } = Eleventy;
 
 function normalize(str) {
@@ -332,4 +333,16 @@ test("`defer` hoisting", async t => {
 	t.deepEqual(normalize(results[2].content), `<style>* { color: blue; }</style>
 <style></style>
 <style></style>`);
+});
+
+test("Ignore missing `file.outputPath` when running under Serverless", async t => {
+	let elev = new EleventyServerless("test1", {
+		path: "/",
+		query: {},
+		inputDir: "./test/stubs/serverless-stubs/",
+		functionsDir: "./test/stubs/serverless-stubs/functions/",
+	});
+
+	let results = await elev.getOutput();
+	t.deepEqual(normalize(results[0].content), `<style>* { color: blue; }</style>`);
 });


### PR DESCRIPTION
## Summary

This PR updates the bundle transform function, allowing `page.outputPath` to be falsy when running under Eleventy Serverless.

This fixes an issue that causes placeholder strings to be rendered in Eleventy Serverless responses.

## Details & Context

When using the shipping version of the bundler plugin in an Eleventy Serverless context, placeholder values are unexpectedly rendered to the resulting page. For example:

```njk
{# src/_includes/layouts/base.njk #}

<!-- Here comes a bundle result! -->
{%- getBundle "html", "head-preconnect" -%}
```

results in an un-transformed placeholder rendered in the response:

```html
<!-- Here comes a bundle result! -->
/*__EleventyBundle:get:html:head-preconnect:EleventyBundle__*/
```

This appears to be the result of the test for `page.outputPath`:

https://github.com/11ty/eleventy-plugin-bundle/blob/5a95ce2e0863722ed8242f3e44cdcd94323a4982/eleventy.shortcodes.js#L63-L66

which is `false` when the page is rendered by Eleventy Serverless:

```javascript
{
  date: 2023-11-24T20:16:56.706Z,
  inputPath: './src/cms/preview.njk',
  fileSlug: 'preview',
  filePathStem: '/cms/preview',
  outputFileExtension: 'html',
  templateSyntax: 'njk',
  url: '/preview/drafts.19ce8ff9-90a7-4507-b3cf-957440d170b4',
  outputPath: false // 👈
}
```

Removing that check when running under Serverless — leaving only the test of whether `content` is a string — results in placeholder replacement by the plugin transform, as expected.
