### PR TITLE
Temporary workaround for Node.js v22 on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["18", "20"]
+        node: ["18", "20", "22"]
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +18,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           # cache: npm
+      # Temporary workaround for Node.js v22 on Windows
+      - if: matrix.node == "22" && runner.os == "Windows"
+        shell: bash  # Not pwsh!!!
+        run: |
+          npm --version  # 10.5.1
+          npm install -g npm  # >= https://github.com/npm/cli/releases/tag/v10.7.0
+          npm --version  # 10.7.0 
       - run: npm install
       - run: npm test
 env:


### PR DESCRIPTION
Workaround for https://github.com/11ty/eleventy/commit/5227f2a7946856b57d5ac162bbf61dad2c9fa3f7