### PR TITLE
WIP: Adds (hacky) tracking of paginations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@11ty/eleventy-plugin-bundle",
-	"version": "3.0.6",
+	"version": "3.0.7",
 	"description": "Little bundles of code, little bundles of joy.",
 	"main": "eleventy.bundle.js",
 	"type": "module",

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -65,6 +65,7 @@ class CodeManager {
 	reset() {
 		this.pages = {};
 		this.paginationPages = {};
+		this.paginationPages = {};
 	}
 
 	static normalizeBuckets(bucket) {
@@ -99,6 +100,7 @@ class CodeManager {
 			this.paginationPages[url].add(u);
 		}
 	}
+
 
 	addToPage(pageUrl, code = [], bucket) {
 		if(!Array.isArray(code) && code) {
@@ -182,9 +184,24 @@ class CodeManager {
 		return result;
 	}
 
-	getRawForPage(pageData, buckets = undefined) {
-		let url = pageData.url;
+	_getRawForPagination(url, buckets) {
+		let result = new Set();
+		for(let subUrl of this.paginationPages[url]) {
+			if(!this.pages[subUrl]) { continue; }
+				for(let b of buckets) {
+					if(!this.pages[subUrl][b]) { continue; }
+					for(let entry of this.pages[subUrl][b]) {
+					result.add(entry);
+				}
+			}
+		}
+		return result;
+	}
+
+	_getRawForPage(url, buckets = undefined) {
+		// Merge data from pagination sub-pages.
 		if(this.paginationPages[url]) {
+			buckets = CodeManager.normalizeBuckets(buckets);
 			return this._getRawForPagination(url, buckets);
 		}
 
@@ -211,6 +228,10 @@ class CodeManager {
 
 		debug("Retrieving %o for %o (buckets: %o, entries: %o, size: %o)", this.name, url, buckets, set.size, size);
 		return set;
+  }
+
+	getRawForPage(pageData, buckets = undefined) {
+		return this._getRawForPage(pageData.url, buckets);
 	}
 
 	async getForPage(pageData, buckets = undefined) {

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -101,7 +101,6 @@ class CodeManager {
 		}
 	}
 
-
 	addToPage(pageUrl, code = [], bucket) {
 		if(!Array.isArray(code) && code) {
 			code = [code];

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -180,7 +180,8 @@ class CodeManager {
 		return result;
 	}
 
-	_getRawForPage(url, buckets = undefined) {
+	getRawForPage(pageData, buckets = undefined) {
+		let url = pageData.url;
 		// Merge data from pagination sub-pages.
 		if(this.paginationPages[url]) {
 			buckets = CodeManager.normalizeBuckets(buckets);
@@ -211,10 +212,6 @@ class CodeManager {
 		debug("Retrieving %o for %o (buckets: %o, entries: %o, size: %o)", this.name, url, buckets, set.size, size);
 		return set;
   }
-
-	getRawForPage(pageData, buckets = undefined) {
-		return this._getRawForPage(pageData.url, buckets);
-	}
 
 	async getForPage(pageData, buckets = undefined) {
 		let set = this.getRawForPage(pageData, buckets);

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -170,9 +170,9 @@ class CodeManager {
 		let result = new Set();
 		for(let subUrl of this.paginationPages[url]) {
 			if(!this.pages[subUrl]) { continue; }
-				for(let b of buckets) {
-					if(!this.pages[subUrl][b]) { continue; }
-					for(let entry of this.pages[subUrl][b]) {
+			for(let b of buckets) {
+				if(!this.pages[subUrl][b]) { continue; }
+				for(let entry of this.pages[subUrl][b]) {
 					result.add(entry);
 				}
 			}

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -64,6 +64,7 @@ class CodeManager {
 
 	reset() {
 		this.pages = {};
+		this.paginationPages = {};
 	}
 
 	static normalizeBuckets(bucket) {
@@ -86,6 +87,16 @@ class CodeManager {
 	_initBucket(pageUrl, bucket) {
 		if(!this.pages[pageUrl][bucket]) {
 			this.pages[pageUrl][bucket] = new Set();
+		}
+	}
+
+	addPaginationUrls(url, subUrls = []) {
+		if(!subUrls.length) { return; }
+		if(!this.paginationPages[url]) {
+			this.paginationPages[url] = new Set();
+		}
+		for(let u of subUrls) {
+			this.paginationPages[url].add(u);
 		}
 	}
 
@@ -142,14 +153,40 @@ class CodeManager {
 
 	getBucketsForPage(pageData) {
 		let pageUrl = pageData.url;
+    if(this.paginationPages[pageUrl]) { // Merge
+      let result = new Set();
+      for(let url of this.paginationPages[pageUrl]) {
+        result = result.union(new Set(this.getBucketsForPage(url)));
+      }
+      return Array.from(result.entries());
+    }
 		if(!this.pages[pageUrl]) {
 			return [];
 		}
 		return Object.keys(this.pages[pageUrl]);
 	}
 
-	getRawForPage(pageData, buckets = undefined) {
-		let url = pageData.url;
+	_getRawForPagination(url, buckets) {
+		let result = new Set();
+		for(let subUrl of this.paginationPages[url]) {
+			if(!this.pages[subUrl]) { continue; }
+				for(let b of buckets) {
+					if(!this.pages[subUrl][b]) { continue; }
+					for(let entry of this.pages[subUrl][b]) {
+					result.add(entry);
+				}
+			}
+		}
+		return result;
+	}
+
+	_getRawForPage(url, buckets = undefined) {
+		// Merge data from pagination sub-pages.
+		if(this.paginationPages[url]) {
+			buckets = CodeManager.normalizeBuckets(buckets);
+			return this._getRawForPagination(url, buckets);
+		}
+
 		if(!this.pages[url]) {
 			debug("No bundle code found for %o on %o, %O", this.name, url, this.pages);
 			return new Set();
@@ -173,6 +210,10 @@ class CodeManager {
 
 		debug("Retrieving %o for %o (buckets: %o, entries: %o, size: %o)", this.name, url, buckets, set.size, size);
 		return set;
+  }
+
+	getRawForPage(pageData, buckets = undefined) {
+		return this._getRawForPage(pageData.url, buckets);
 	}
 
 	async getForPage(pageData, buckets = undefined) {

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -211,7 +211,7 @@ class CodeManager {
 
 		debug("Retrieving %o for %o (buckets: %o, entries: %o, size: %o)", this.name, url, buckets, set.size, size);
 		return set;
-  }
+	}
 
 	async getForPage(pageData, buckets = undefined) {
 		let set = this.getRawForPage(pageData, buckets);

--- a/src/CodeManager.js
+++ b/src/CodeManager.js
@@ -168,6 +168,8 @@ class CodeManager {
 
 	_getRawForPagination(url, buckets) {
 		let result = new Set();
+		buckets = CodeManager.normalizeBuckets(buckets);
+		// Merge data from pagination sub-pages.
 		for(let subUrl of this.paginationPages[url]) {
 			if(!this.pages[subUrl]) { continue; }
 			for(let b of buckets) {
@@ -182,9 +184,7 @@ class CodeManager {
 
 	getRawForPage(pageData, buckets = undefined) {
 		let url = pageData.url;
-		// Merge data from pagination sub-pages.
 		if(this.paginationPages[url]) {
-			buckets = CodeManager.normalizeBuckets(buckets);
 			return this._getRawForPagination(url, buckets);
 		}
 

--- a/src/eleventy.shortcodes.js
+++ b/src/eleventy.shortcodes.js
@@ -56,6 +56,15 @@ function eleventyBundleShortcodes(eleventyConfig, pluginOptions = {}) {
 		if(url) {
 			pagesUsingBundles[url] = true;
 		}
+		let paginationUrls = (this?.ctx?.pagination?.items || []).
+													filter((i) => !!(i?.url)).
+													map((i) => i.url);
+		if(paginationUrls.length) {
+			paginationUrls.forEach((u) => {
+				pagesUsingBundles[u] = true;
+			})
+			managers[type].addPaginationUrls(url, paginationUrls);
+		}
 
 		return OutOfOrderRender.getAssetKey("get", type, bucket);
 	});

--- a/src/eleventy.shortcodes.js
+++ b/src/eleventy.shortcodes.js
@@ -3,19 +3,14 @@ import debugUtil from "debug";
 
 const debug = debugUtil("Eleventy:Bundle");
 
-function eleventyBundleShortcodes(eleventyConfig, pluginOptions = {}) {
+export default function(eleventyConfig, pluginOptions = {}) {
 	let managers = eleventyConfig.getBundleManagers();
 	let writeToFileSystem = true;
-	let pagesUsingBundles = {};
 
 	function bundleTransform(content, stage = 0) {
-		if(typeof content !== "string") {
-			return content;
-		}
-
+		// Only run if content is string
 		// Only run if managers are in play
-		// Only run on pages that have fetched bundles via `getBundle` or `getBundleFileUrl`
-		if(Object.keys(managers).length === 0 || this.page.url && !pagesUsingBundles[this.page.url]) {
+		if(typeof content !== "string" || Object.keys(managers).length === 0) {
 			return content;
 		}
 
@@ -35,8 +30,6 @@ function eleventyBundleShortcodes(eleventyConfig, pluginOptions = {}) {
 		if(Object.keys(managers).length === 0) {
 			return;
 		}
-
-		pagesUsingBundles = {};
 
 		if(outputMode !== "fs") {
 			writeToFileSystem = false;
@@ -76,11 +69,6 @@ function eleventyBundleShortcodes(eleventyConfig, pluginOptions = {}) {
 			throw new Error(`Invalid bundle type: ${type}. Available options: ${Object.keys(managers)}`);
 		}
 
-		let url = explicitUrl || this.page?.url;
-		if(url) {
-			pagesUsingBundles[url] = true;
-		}
-
 		return OutOfOrderRender.getAssetKey("file", type, bucket);
 	});
 
@@ -107,5 +95,3 @@ function eleventyBundleShortcodes(eleventyConfig, pluginOptions = {}) {
 		});
 	});
 };
-
-export default eleventyBundleShortcodes;

--- a/src/eleventy.shortcodes.js
+++ b/src/eleventy.shortcodes.js
@@ -37,6 +37,8 @@ export default function(eleventyConfig, pluginOptions = {}) {
 		}
 	});
 
+  let pagesUsingBundles = {};
+
 	// e.g. `getBundle` shortcode to get code in current page bundle
 	// bucket can be an array
 	// This shortcode name is not configurable on purpose (for wider plugin compatibility)

--- a/test/stubs/pagination-support/_includes/template.njk
+++ b/test/stubs/pagination-support/_includes/template.njk
@@ -1,0 +1,5 @@
+{% getBundle "css" %}
+
+{%- for post in pagination.items -%}
+  {{ post.content | safe }}
+{%- endfor -%}

--- a/test/stubs/pagination-support/eleventy.config.js
+++ b/test/stubs/pagination-support/eleventy.config.js
@@ -1,0 +1,15 @@
+import bundlePlugin from "../../../eleventy.bundle.js";
+
+export default function(eleventyConfig) {
+	eleventyConfig.addPlugin(bundlePlugin, {
+		force: true, // for testing
+		immediate: true,
+    // toFileDirectory: "bundle",
+    bundles: false,
+	});
+
+	// eleventyConfig.addBundle("css");
+	eleventyConfig.addBundle("css", {
+		bundleHtmlContentFromSelector: "style",
+	});
+};

--- a/test/stubs/pagination-support/index.md
+++ b/test/stubs/pagination-support/index.md
@@ -1,0 +1,9 @@
+---
+pagination:
+  data: collections.all
+  size: 2
+  alias: posts
+templateEngineOverride: njk,md
+layout: "./template.njk"
+---
+

--- a/test/stubs/pagination-support/post1.md
+++ b/test/stubs/pagination-support/post1.md
@@ -1,0 +1,12 @@
+---
+title: "Post 1"
+templateEngineOverride: njk,md
+---
+
+{% css %}
+<style>#foo { border: 1px solid blue; }</style>
+{% endcss %}
+
+# First Post!!!!!
+
+*sigh*

--- a/test/stubs/pagination-support/post2.md
+++ b/test/stubs/pagination-support/post2.md
@@ -1,0 +1,12 @@
+---
+title: "Post 2"
+templateEngineOverride: njk,md
+---
+
+{% css %}
+<style>#bar { border: 1px solid red; }</style>
+{% endcss %}
+
+# Second
+
+Was this a good idea?

--- a/test/stubs/pagination-support/post3.md
+++ b/test/stubs/pagination-support/post3.md
@@ -1,0 +1,12 @@
+---
+title: "Post 3"
+templateEngineOverride: njk,md
+---
+
+{% css %}
+<style>#baz { outline: 1px dotted orange; }</style>
+{% endcss %}
+
+# Third
+
+**Running out of steam.**

--- a/test/test.js
+++ b/test/test.js
@@ -484,3 +484,22 @@ test("<style> plucked into bundle with buckets", async t => {
 	t.deepEqual(normalize(results[0].content), `<div></div><style>@layer layer1 { * { color: yellow }
 body { color: blue } } @layer layer2 { * { color: red } } * { color: orange }</style>`)
 });
+
+
+test("Pagination support", async t => {
+	let elev = new Eleventy("test/stubs/pagination-support/", undefined, { 
+		configPath: "test/stubs/pagination-support/eleventy.config.js",
+		config: function(eleventyConfig) {
+			eleventyConfig.setQuietMode(true);
+		}
+	});
+	await elev.write();
+	t.deepEqual(
+			normalize(fs.readFileSync("_site/index.html", "utf8")), 
+			`<style>#foo { border: 1px solid blue; }</style>
+<style>#bar { border: 1px solid red; }</style><h1>First Post!!!!!</h1>
+<p><em>sigh</em></p>
+<h1>Second</h1>
+<p>Was this a good idea?</p>`
+	);
+});


### PR DESCRIPTION
Fixes #37

The basic idea is that blocks declared in pages iterated over via frontmatter paginations will be available to the paginating page as well as the pages declaring the blocks. This has some limitations. For instance, iterations over collections aren't handled; e.g. in the front page of the 11ty base blog project. Sites that grab `templateContent` from a collection without a paginating over the same collection won't get merged blocks, but this is the status quo so I'm not sure how bad that is.