### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/11ty/eleventy-plugin-bundle.git"
+		"url": "git+https://github.com/11ty/eleventy-plugin-bundle.git"
 	},
 	"bugs": "https://github.com/11ty/eleventy-plugin-bundle/issues",
 	"homepage": "https://www.11ty.dev/",


### PR DESCRIPTION
## Summary

- update `package.json` repository metadata from legacy `git://` to `git+https://`
- keep the existing public GitHub repository target unchanged

## Why

The package is public, so HTTPS repository metadata is easier for npm clients, scanners, and environments that block the legacy unauthenticated git protocol to consume.

## Validation

- Parsed `package.json` with Node and verified `repository.url` is `git+https://github.com/11ty/eleventy-plugin-bundle.git`.