### PR TITLE
Fix content-controlled bundle-directive injection via predictable placeholder

### DIFF
--- a/src/OutOfOrderRender.js
+++ b/src/OutOfOrderRender.js
@@ -1,12 +1,20 @@
+import { randomBytes } from "node:crypto";
 import { createDebug } from "obug";
 
 const debug = createDebug("Eleventy:Bundle");
+
+// Generated once per process (i.e. once per build/serve run) so that page content
+// can never be authored in advance to coincidentally collide with a live placeholder.
+// See https://github.com/11ty/eleventy-plugin-bundle/issues/54
+const BUNDLE_TOKEN = randomBytes(12).toString("hex");
+const PREFIX = `<!--#BaBundle:${BUNDLE_TOKEN}:`;
+const PREFIX_NO_COMMENT = `#BaBundle:${BUNDLE_TOKEN}:`;
 
 /* This class defers any `bundleGet` calls to a post-build transform step,
  * to allow `getBundle` to be called before all of the `css` additions have been processed
  */
 export class OutOfOrderRender {
-	#regex = /((?:\<\!\-\-)#BaBundle:[^:]*:[^:]*:[^:]*:BaBundle#(?:\-\-\>))/;
+	#regex = new RegExp(`((?:\\<\\!\\-\\-)#BaBundle:${BUNDLE_TOKEN}:[^:]*:[^:]*:[^:]*:BaBundle#(?:\\-\\-\\>))`);
 
 	static SEPARATOR = ":";
 
@@ -23,12 +31,12 @@ export class OutOfOrderRender {
 		} else {
 			bucket = "";
 		}
-		return `<!--#BaBundle:${type}:${name}:${bucket || "default"}:BaBundle#-->`;
+		return `${PREFIX}${type}:${name}:${bucket || "default"}:BaBundle#-->`;
 	}
 
 	static parseAssetKey(str) {
-		if(str.startsWith("#BaBundle:") || str.startsWith("<!--#BaBundle:")) {
-			let [prefix, type, name, bucket, suffix] = str.split(OutOfOrderRender.SEPARATOR);
+		if(str.startsWith(PREFIX_NO_COMMENT) || str.startsWith(PREFIX)) {
+			let [prefix, token, type, name, bucket, suffix] = str.split(OutOfOrderRender.SEPARATOR);
 			return { type, name, bucket };
 		}
 		return false;


### PR DESCRIPTION
Fixes #54.

## Summary

`getBundle`/`getBundleFileUrl` emitted a placeholder with a fixed, predictable literal pattern (`<!--#BaBundle:type:name:bucket:BaBundle#-->`), and the post-render transform scanned the **entire page content** for that pattern with no way to distinguish a real shortcode-emitted placeholder from the identical string appearing as ordinary page content (e.g. typed in a blog post, or present in documentation about this exact plugin syntax). Any page containing that literal string got it replaced too, including triggering a real file write for the `file`-type placeholder.

## Fix

Generate a random token once per process (i.e. once per build/serve run) and require it in the placeholder pattern, so content authored in advance — before the token exists — can never coincidentally collide with a live placeholder:

```js
const BUNDLE_TOKEN = randomBytes(12).toString("hex");
const PREFIX = `<!--#BaBundle:${BUNDLE_TOKEN}:`;
```

## Verification

- Full existing test suite: 46/46 passing, 4 pre-existing skips, no regressions.
- PoC:
  ```js
  const legitPlaceholder = OutOfOrderRender.getAssetKey("get", "css", "default");
  // "<!--#BaBundle:b3ba547aa4a41ca235b52207:get:css:default:BaBundle#-->"  (random token)

  const guessedOldPlaceholder = "<!--#BaBundle:get:css:default:BaBundle#-->"; // pre-fix format
  const content = `<style>${legitPlaceholder}</style><p>Attacker guesses the old pattern: ${guessedOldPlaceholder}</p>`;
  await renderer.replaceAll({ url: "/page1/" });
  ```
  Output: the real placeholder is correctly substituted with bundle content, while the attacker's guess at the old fixed pattern passes through untouched as plain text.

See #54 for the full report and original reproduction.